### PR TITLE
[dagster-k8s] working op mutating executor

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/op_mutating_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/op_mutating_executor.py
@@ -1,0 +1,251 @@
+from typing import Any, Mapping, NamedTuple, Optional, TypeVar, cast
+
+from dagster import (
+    Field,
+    IOManager,
+    StepRunRef,
+    TypeCheck,
+    _check as check,
+    executor,
+    usable_as_dagster_type,
+)
+from dagster._core.definitions.executor_definition import multiple_process_executor_requirements
+from dagster._core.execution.context.system import StepOrchestrationContext
+from dagster._core.execution.plan.external_step import step_run_ref_to_step_context
+from dagster._core.execution.plan.inputs import (
+    FromPendingDynamicStepOutput,
+    FromStepOutput,
+    StepInput,
+)
+from dagster._core.execution.retries import RetryMode
+from dagster._core.executor.base import Executor
+from dagster._core.executor.init import InitExecutorContext
+from dagster._core.executor.step_delegating import StepDelegatingExecutor, StepHandlerContext
+from dagster._core.storage.input_manager import InputManager
+from dagster._utils.merger import merge_dicts
+
+from dagster_k8s.container_context import K8sContainerContext
+from dagster_k8s.executor import _K8S_EXECUTOR_CONFIG_SCHEMA, K8sStepHandler
+from dagster_k8s.job import UserDefinedDagsterK8sConfig
+from dagster_k8s.launcher import K8sRunLauncher
+
+_K8S_OP_EXECUTOR_CONFIG_SCHEMA = merge_dicts(
+    _K8S_EXECUTOR_CONFIG_SCHEMA,
+    {
+        "op_mutation_enabled": Field(
+            bool,
+            default_value=False,
+            description="enabled op configuration based on output of prior op",
+        )
+    },
+)
+
+T = TypeVar("T")
+
+
+@usable_as_dagster_type
+class K8sOpMutatingOutput:
+    k8s_config: UserDefinedDagsterK8sConfig
+    value: Any
+
+    def __init__(
+        self, k8s_config: UserDefinedDagsterK8sConfig | Mapping[str, Any], value: Any = None
+    ):
+        if isinstance(k8s_config, dict):
+            check.mapping_param(k8s_config, "k8s_config", str)
+            k8s_config = UserDefinedDagsterK8sConfig.from_dict(k8s_config)
+        else:
+            check.inst_param(k8s_config, "k8s_config", UserDefinedDagsterK8sConfig)
+        self.k8s_config = k8s_config
+        self.value = value
+
+    @classmethod
+    def type_check(cls, _context, value):
+        _ = _context
+        if not isinstance(value, cls):
+            return TypeCheck(
+                success=False, description=f"expected wrapper class {type(K8sOpMutatingOutput)}"
+            )
+        return TypeCheck(success=True)
+
+
+class StepInputCacheKey(NamedTuple):
+    step_key: str
+    input_name: str
+
+
+class K8sMutatingStepHandler(K8sStepHandler):
+    """Specialized step handler that configure the next op based on the op metadata of the prior op."""
+
+    op_mutation_enabled: bool
+    step_input_cache: dict[StepInputCacheKey, UserDefinedDagsterK8sConfig]
+
+    def __init__(
+        self,
+        image: str | None,
+        container_context: K8sContainerContext,
+        load_incluster_config: bool,
+        kubeconfig_file: str | None,
+        k8s_client_batch_api=None,
+        op_mutation_enabled: bool = False,
+    ):
+        self.op_mutation_enabled = op_mutation_enabled
+        self.step_input_cache = {}
+        super().__init__(
+            image, container_context, load_incluster_config, kubeconfig_file, k8s_client_batch_api
+        )
+
+    def _get_input_metadata(
+        self, step_input: StepInput, step_context: StepOrchestrationContext
+    ) -> Optional[UserDefinedDagsterK8sConfig]:
+        # dagster type names should be garunteed unique, so this should be safe
+        if step_input.dagster_type_key != K8sOpMutatingOutput.__name__:
+            return {}
+        step_cache_key = StepInputCacheKey(step_context.step.key, step_input.name)
+        if step_cache_key in self.step_input_cache:
+            step_context.log.debug(f"cache hit for key {step_cache_key}")
+            return self.step_input_cache[step_cache_key]
+        source = step_input.source
+        if isinstance(source, FromPendingDynamicStepOutput):
+            upstream_output_handle = source.step_output_handle
+            # coerce FromPendingDynamicStepOutput to FromStepOutputSource
+            source = source.resolve(upstream_output_handle.mapping_key)
+        if not isinstance(source, FromStepOutput):
+            return step_context.log.error(
+                f"unable to consume {step_input.name}. FromStepOuput & FromPendingDynamicStepOutput sources supported, got {type(source)}"
+            )
+        if source.fan_in:
+            return step_context.log.error("fan in step input not supported")
+        job_def = step_context.job.get_definition()
+        # lie, cheat, and steal. Create step execution context ahead of time
+        step_run_ref = StepRunRef(
+            run_config=job_def.run_config or {},
+            dagster_run=step_context.dagster_run,
+            run_id=step_context.run_id,
+            step_key=step_context.step.key,
+            retry_mode=step_context.retry_mode,
+            recon_job=step_context.reconstructable_job,
+            known_state=step_context.execution_plan.known_state,
+        )
+        step_exec_context = step_run_ref_to_step_context(step_run_ref, step_context.instance)
+        input_def = job_def.get_op(step_context.step.node_handle).input_def_named(step_input.name)
+        output_handle = source.step_output_handle
+        # get requisite input manager
+        if input_def.input_manager_key is not None:
+            manager_key = input_def.input_manager_key
+            input_manager = getattr(step_exec_context.resources, manager_key)
+            check.invariant(
+                isinstance(input_manager, InputManager),
+                f'Input "{input_def.name}" for step "{step_context.step.key}" is depending on '
+                f'the manager "{manager_key}" to load it, but it is not an InputManager. '
+                "Please ensure that the resource returned for resource key "
+                f'"{manager_key}" is an InputManager.',
+            )
+        else:
+            manager_key = step_context.execution_plan.get_manager_key(
+                source.step_output_handle, job_def
+            )
+            input_manager = step_exec_context.get_io_manager(output_handle)
+            check.invariant(
+                isinstance(input_manager, IOManager),
+                f'Input "{input_def.name}" for step "{step_context.step.key}" is depending on '
+                f'the manager of upstream output "{output_handle.output_name}" from step '
+                f'"{output_handle.step_key}" to load it, but that manager is not an IOManager. '
+                "Please ensure that the resource returned for resource key "
+                f'"{manager_key}" is an IOManager.',
+            )
+        # load full input via input manager. DANGER, if value is excessively large this could have perf impacts on stephandler
+        input_context = source.get_load_context(step_exec_context, input_def, manager_key)
+        op_mutating_output: K8sOpMutatingOutput = input_manager.load_input(input_context)
+        step_context.log.debug(f"eagerly recieved input {op_mutating_output}")
+        self.step_input_cache[step_cache_key] = op_mutating_output.k8s_config
+        return self.step_input_cache[step_cache_key]
+
+    def _resolve_input_configs(
+        self, step_handler_context: StepHandlerContext
+    ) -> Optional[K8sContainerContext]:
+        """Fetch all the configured k8s metadata for op inputs."""
+        step_key = self._get_step_key(step_handler_context)
+        step_context = step_handler_context.get_step_context(step_key)
+        container_context = None
+        for step_input in step_context.step.step_inputs:
+            op_metadata_config = self._get_input_metadata(step_input, step_context)
+            if not op_metadata_config:
+                continue
+            k8s_context = K8sContainerContext(run_k8s_config=op_metadata_config)
+            if container_context is None:
+                container_context = k8s_context
+            else:
+                container_context.merge(k8s_context)
+        return container_context
+
+    def _get_container_context(
+        self, step_handler_context: StepHandlerContext
+    ) -> K8sContainerContext:
+        context = super()._get_container_context(step_handler_context)
+        if not self.op_mutation_enabled:
+            return context
+        merged_input_k8s_configs = self._resolve_input_configs(step_handler_context)
+        if merged_input_k8s_configs:
+            return context.merge(merged_input_k8s_configs)
+        return context
+
+    def terminate_step(self, step_handler_context):
+        yield from super().terminate_step(step_handler_context)
+        # pop cache to save mem for steps we won't visit again
+        step_key = self._get_step_key(step_handler_context)
+        stale_cache_keys = [k for k in self.step_input_cache if k.step_key == step_key]
+        for k in stale_cache_keys:
+            self.step_input_cache.pop(k)
+
+
+@executor(
+    name="k8s_op_mutating",
+    config_schema=_K8S_OP_EXECUTOR_CONFIG_SCHEMA,
+    requirements=multiple_process_executor_requirements(),
+)
+def k8s_op_mutating_executor(init_context: InitExecutorContext) -> Executor:
+    assert isinstance(init_context.instance.run_launcher, K8sRunLauncher)
+    run_launcher = init_context.instance.run_launcher
+    exc_cfg = init_context.executor_config
+    k8s_container_context = K8sContainerContext(
+        image_pull_policy=exc_cfg.get("image_pull_policy"),  # type: ignore
+        image_pull_secrets=exc_cfg.get("image_pull_secrets"),  # type: ignore
+        service_account_name=exc_cfg.get("service_account_name"),  # type: ignore
+        env_config_maps=exc_cfg.get("env_config_maps"),  # type: ignore
+        env_secrets=exc_cfg.get("env_secrets"),  # type: ignore
+        env_vars=exc_cfg.get("env_vars"),  # type: ignore
+        volume_mounts=exc_cfg.get("volume_mounts"),  # type: ignore
+        volumes=exc_cfg.get("volumes"),  # type: ignore
+        labels=exc_cfg.get("labels"),  # type: ignore
+        namespace=exc_cfg.get("job_namespace"),  # type: ignore
+        resources=exc_cfg.get("resources"),  # type: ignore
+        scheduler_name=exc_cfg.get("scheduler_name"),  # type: ignore
+        security_context=exc_cfg.get("security_context"),  # type: ignore
+        # step_k8s_config feeds into the run_k8s_config field because it is merged
+        # with any configuration for the run that was set on the run launcher or code location
+        run_k8s_config=UserDefinedDagsterK8sConfig.from_dict(exc_cfg.get("step_k8s_config", {})),
+    )
+    if "load_incluster_config" in exc_cfg:
+        load_incluster_config = cast(bool, exc_cfg["load_incluster_config"])
+    else:
+        load_incluster_config = run_launcher.load_incluster_config if run_launcher else True
+    if "kubeconfig_file" in exc_cfg:
+        kubeconfig_file = cast(Optional[str], exc_cfg["kubeconfig_file"])
+    else:
+        kubeconfig_file = run_launcher.kubeconfig_file if run_launcher else None
+    op_mutation_enabled = exc_cfg.get("op_mutation_enabled", False)
+    check.bool_param(op_mutation_enabled, "op_mutation_enabled")
+    return StepDelegatingExecutor(
+        K8sMutatingStepHandler(
+            image=exc_cfg.get("job_image"),  # type: ignore
+            container_context=k8s_container_context,
+            load_incluster_config=load_incluster_config,
+            kubeconfig_file=kubeconfig_file,
+            op_mutation_enabled=op_mutation_enabled,
+        ),
+        retries=RetryMode.from_config(exc_cfg["retries"]),  # type: ignore
+        max_concurrent=check.opt_int_elem(exc_cfg, "max_concurrent"),
+        tag_concurrency_limits=check.opt_list_elem(exc_cfg, "tag_concurrency_limits"),
+        should_verify_step=True,
+    )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/op_mutating_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/op_mutating_executor.py
@@ -70,6 +70,7 @@ class K8sOpMutatingOutput:
 
 
 class StepInputCacheKey(NamedTuple):
+    run_id: str
     step_key: str
     input_name: str
 
@@ -101,7 +102,9 @@ class K8sMutatingStepHandler(K8sStepHandler):
         # dagster type names should be garunteed unique, so this should be safe
         if step_input.dagster_type_key != K8sOpMutatingOutput.__name__:
             return {}
-        step_cache_key = StepInputCacheKey(step_context.step.key, step_input.name)
+        step_cache_key = StepInputCacheKey(
+            step_context.run_id, step_context.step.key, step_input.name
+        )
         if step_cache_key in self.step_input_cache:
             step_context.log.debug(f"cache hit for key {step_cache_key}")
             return self.step_input_cache[step_cache_key]

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/op_mutating_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/op_mutating_executor.py
@@ -116,12 +116,18 @@ class K8sMutatingStepHandler(K8sStepHandler):
         load_incluster_config: bool,
         kubeconfig_file: Optional[str],
         k8s_client_batch_api=None,
+        per_step_k8s_config=None,
         op_mutation_enabled: bool = False,
     ):
         self.op_mutation_enabled = op_mutation_enabled
         self.container_ctx_cache = {}
         super().__init__(
-            image, container_context, load_incluster_config, kubeconfig_file, k8s_client_batch_api
+            image=image,
+            container_context=container_context,
+            load_incluster_config=load_incluster_config,
+            kubeconfig_file=kubeconfig_file,
+            k8s_client_batch_api=k8s_client_batch_api,
+            per_step_k8s_config=per_step_k8s_config,
         )
 
     @property
@@ -294,6 +300,7 @@ def k8s_op_mutating_executor(init_context: InitExecutorContext) -> Executor:
             container_context=k8s_container_context,
             load_incluster_config=load_incluster_config,
             kubeconfig_file=kubeconfig_file,
+            per_step_k8s_config=exc_cfg.get("per_step_k8s_config", {}),
             op_mutation_enabled=op_mutation_enabled,
         ),
         retries=RetryMode.from_config(exc_cfg["retries"]),  # type: ignore

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/conftest.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/conftest.py
@@ -55,3 +55,26 @@ def k8s_run_launcher_instance(kubeconfig_file):
             }
         ) as instance:
             yield instance
+
+
+@pytest.fixture
+def k8s_instance(kubeconfig_file):
+    default_config = {
+        "service_account_name": "webserver-admin",
+        "instance_config_map": "dagster-instance",
+        "postgres_password_secret": "dagster-postgresql-secret",
+        "dagster_home": "/opt/dagster/dagster_home",
+        "job_image": "fake_job_image",
+        "load_incluster_config": False,
+        "kubeconfig_file": kubeconfig_file,
+    }
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster_k8s",
+                "class": "K8sRunLauncher",
+                "config": default_config,
+            }
+        }
+    ) as instance:
+        yield instance

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_mutating_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_mutating_executor.py
@@ -1,0 +1,192 @@
+from typing import List
+from unittest import mock
+
+from dagster import (
+    DagsterInstance,
+    DagsterRun,
+    Executor,
+    InitExecutorContext,
+    IOManager,
+    JobDefinition,
+    OpExecutionContext,
+    StepExecutionContext,
+    job,
+    op,
+    reconstructable,
+)
+from dagster._config import process_config, resolve_to_config_type
+from dagster._core.execution.api import create_execution_plan
+from dagster._core.execution.context.system import PlanData, PlanOrchestrationContext
+from dagster._core.execution.context_creation_job import create_context_free_log_manager
+from dagster._core.execution.retries import RetryMode
+from dagster._core.executor.step_delegating import StepHandlerContext
+from dagster._grpc.types import ExecuteStepArgs
+from dagster_k8s.container_context import K8sContainerContext
+from dagster_k8s.op_mutating_executor import (
+    _K8S_OP_EXECUTOR_CONFIG_SCHEMA,
+    K8sMutatingStepHandler,
+    K8sOpMutatingOutput,
+    k8s_op_mutating_executor,
+)
+
+from dagster_k8s_tests.unit_tests.test_executor import k8s_instance
+
+_ = k8s_instance
+
+MOCK_RUNTIME_RESOURCE_CONF = {
+    "resources": {
+        "requests": {"cpu": "3500m", "memory": "4Gi"},
+        "limits": {"cpu": "4200m", "memory": "5Gi"},
+    }
+}
+MOCK_K8s_OUTPUT = K8sOpMutatingOutput({"container_config": MOCK_RUNTIME_RESOURCE_CONF})
+
+
+class MockIOManager(IOManager):
+    def load_input(self, context):
+        return MOCK_K8s_OUTPUT
+
+    def handle_output(self, context, obj): ...
+
+
+@job
+def simple_producer_consumer():
+    @op
+    def producer() -> K8sOpMutatingOutput:
+        return MOCK_K8s_OUTPUT
+
+    @op
+    def sink(context: OpExecutionContext, producer: K8sOpMutatingOutput):
+        context.log.info(f"received the following input: {producer}")
+
+    sink(producer())
+
+
+def _fetch_step_handler_context(
+    job_def: JobDefinition,
+    dagster_run: DagsterRun,
+    instance: DagsterInstance,
+    executor: Executor,
+    steps: List[str],
+):
+    execution_plan = create_execution_plan(job_def)
+    log_manager = create_context_free_log_manager(instance, dagster_run)
+
+    plan_context = PlanOrchestrationContext(
+        plan_data=PlanData(
+            job=job_def,
+            dagster_run=dagster_run,
+            instance=instance,
+            execution_plan=execution_plan,
+            raise_on_error=True,
+            retry_mode=RetryMode.DISABLED,
+        ),
+        log_manager=log_manager,
+        executor=executor,
+        output_capture=None,
+    )
+
+    execute_step_args = ExecuteStepArgs(
+        job_def.get_python_origin(),
+        dagster_run.run_id,
+        steps,
+        print_serialized_events=False,
+    )
+
+    return StepHandlerContext(
+        instance=instance,
+        plan_context=plan_context,
+        steps=execution_plan.steps,
+        execute_step_args=execute_step_args,
+    )
+
+
+def _fetch_mutating_executor(
+    instance: DagsterInstance, job_def: JobDefinition, executor_config=None
+):
+    process_result = process_config(
+        resolve_to_config_type(_K8S_OP_EXECUTOR_CONFIG_SCHEMA),
+        executor_config or {},
+    )
+    assert process_result.success, str(process_result.errors)
+
+    return k8s_op_mutating_executor.executor_creation_fn(
+        InitExecutorContext(
+            job=job_def,
+            executor_def=k8s_op_mutating_executor,
+            executor_config=process_result.value,
+            instance=instance,
+        )
+    )
+
+
+def test_mutating_step_handler_runtime_override(
+    k8s_instance: DagsterInstance, tmp_path, kubeconfig_file
+):
+    mock_k8s_client_batch_api = mock.MagicMock()
+    # io_manager = mem_io_manager
+    result = simple_producer_consumer.execute_in_process(instance=k8s_instance)
+    assert result.success
+    recon_job = reconstructable(simple_producer_consumer)
+    executor = _fetch_mutating_executor(k8s_instance, recon_job)
+    step_handler_ctx = _fetch_step_handler_context(
+        recon_job, result.dagster_run, k8s_instance, executor, ["sink"]
+    )
+    handler = K8sMutatingStepHandler(
+        image="bizbuz",
+        container_context=K8sContainerContext(
+            namespace="foo",
+            resources={
+                "requests": {"cpu": "128m", "memory": "64Mi"},
+                "limits": {"cpu": "500m", "memory": "1000Mi"},
+            },
+        ),
+        load_incluster_config=False,
+        kubeconfig_file=kubeconfig_file,
+        k8s_client_batch_api=mock_k8s_client_batch_api,
+        op_mutation_enabled=True,
+    )
+    with mock.patch.object(
+        StepExecutionContext, "get_io_manager", mock.MagicMock(return_value=MockIOManager())
+    ):
+        runtime_mutated_context = handler._get_container_context(step_handler_ctx)  # noqa: SLF001
+    assert (
+        runtime_mutated_context.run_k8s_config.container_config.get("resources")
+        == MOCK_RUNTIME_RESOURCE_CONF["resources"]
+    )
+
+
+def test_mutating_step_handler_no_runtime_override(
+    k8s_instance: DagsterInstance, tmp_path, kubeconfig_file
+):
+    mock_k8s_client_batch_api = mock.MagicMock()
+    # io_manager = mem_io_manager
+    result = simple_producer_consumer.execute_in_process(instance=k8s_instance)
+    assert result.success
+    recon_job = reconstructable(simple_producer_consumer)
+    executor = _fetch_mutating_executor(k8s_instance, recon_job)
+    step_handler_ctx = _fetch_step_handler_context(
+        recon_job, result.dagster_run, k8s_instance, executor, ["sink"]
+    )
+    handler = K8sMutatingStepHandler(
+        image="bizbuz",
+        container_context=K8sContainerContext(
+            namespace="foo",
+            resources={
+                "requests": {"cpu": "128m", "memory": "64Mi"},
+                "limits": {"cpu": "500m", "memory": "1000Mi"},
+            },
+        ),
+        load_incluster_config=False,
+        kubeconfig_file=kubeconfig_file,
+        k8s_client_batch_api=mock_k8s_client_batch_api,
+        op_mutation_enabled=False,
+    )
+    with mock.patch.object(
+        StepExecutionContext, "get_io_manager", mock.MagicMock(return_value=MockIOManager())
+    ):
+        runtime_mutated_context = handler._get_container_context(step_handler_ctx)  # noqa: SLF001
+    assert runtime_mutated_context.run_k8s_config.container_config.get("resources") == {
+        "requests": {"cpu": "128m", "memory": "64Mi"},
+        "limits": {"cpu": "500m", "memory": "1000Mi"},
+    }

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_mutating_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_mutating_executor.py
@@ -1,18 +1,20 @@
+from dataclasses import dataclass
 from typing import List, Sequence, cast
 from unittest import mock
 
+import pytest
 from dagster import (
     DagsterInstance,
     DagsterRun,
     DynamicOut,
     DynamicOutput,
     Executor,
+    In,
     InitExecutorContext,
-    InMemoryIOManager,
-    IOManagerDefinition,
+    JsonMetadataValue,
     OpExecutionContext,
-    StepExecutionContext,
-    io_manager,
+    Out,
+    Output,
     job,
     op,
     reconstructable,
@@ -26,12 +28,16 @@ from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.execution.plan.step import ExecutionStep
 from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.step_delegating import StepHandlerContext
+from dagster._core.storage.event_log import SqlEventLogStorage
 from dagster._grpc.types import ExecuteStepArgs
 from dagster_k8s.container_context import K8sContainerContext
+from dagster_k8s.job import USER_DEFINED_K8S_CONFIG_KEY, UserDefinedDagsterK8sConfig
 from dagster_k8s.op_mutating_executor import (
     _K8S_OP_EXECUTOR_CONFIG_SCHEMA,
+    USER_DEFINED_INPUT_K8S_OP_MUTATION_KEY,
     K8sMutatingStepHandler,
-    K8sOpMutatingOutput,
+    K8sOpMutatingWrapper,
+    get_output_records_for_run_step,
     k8s_op_mutating_executor,
 )
 
@@ -45,17 +51,21 @@ MOCK_RUNTIME_RESOURCE_CONF = {
         "limits": {"cpu": "4200m", "memory": "5Gi"},
     }
 }
-MOCK_K8s_OUTPUT = K8sOpMutatingOutput({"container_config": MOCK_RUNTIME_RESOURCE_CONF})
 
 
 @job
-def simple_producer_consumer():
-    @op
-    def producer() -> K8sOpMutatingOutput:
-        return MOCK_K8s_OUTPUT
+def simple_producer_consumer_job():
+    @op(out=Out(K8sOpMutatingWrapper))
+    def producer():
+        return Output(
+            K8sOpMutatingWrapper[int](1),
+            metadata={
+                USER_DEFINED_K8S_CONFIG_KEY: {"container_config": MOCK_RUNTIME_RESOURCE_CONF}
+            },
+        )
 
     @op
-    def sink(context: OpExecutionContext, producer: K8sOpMutatingOutput) -> KnownExecutionState:
+    def sink(context: OpExecutionContext, producer: K8sOpMutatingWrapper) -> KnownExecutionState:
         _ = producer
         return context.get_step_execution_context().get_known_state()
 
@@ -63,30 +73,108 @@ def simple_producer_consumer():
 
 
 @job
-def dynamic_producer_consumer():
-    @op(out=DynamicOut(K8sOpMutatingOutput))
+def dynamic_producer_consumer_job():
+    @op(out=DynamicOut(K8sOpMutatingWrapper))
     def dyn_producer():
         for i in [3, 4]:
-            k8s_out = K8sOpMutatingOutput(
-                {
-                    "container_config": {
-                        "resources": {
-                            "requests": {"cpu": f"{i}234m", "memory": f"{i}Gi"},
-                            "limits": {"cpu": f"{i}765m", "memory": f"{i}Gi"},
+            k8s_out = K8sOpMutatingWrapper[int](1)
+            yield DynamicOutput(
+                k8s_out,
+                str(i),
+                metadata={
+                    USER_DEFINED_K8S_CONFIG_KEY: {
+                        "container_config": {
+                            "resources": {
+                                "requests": {"cpu": f"{i}234m", "memory": f"{i}Gi"},
+                                "limits": {"cpu": f"{i}765m", "memory": f"{i}Gi"},
+                            }
                         }
                     }
-                }
+                },
             )
-            yield DynamicOutput(k8s_out, str(i))
 
     @op
-    def dyn_sink(context: OpExecutionContext, producer: K8sOpMutatingOutput) -> KnownExecutionState:
+    def dyn_sink(
+        context: OpExecutionContext, producer: K8sOpMutatingWrapper
+    ) -> KnownExecutionState:
         context.log.info(f"received the following input: {producer}")
-        # hacky way for me to get known context -> InMemIOManager -> StepOrchestrationContext
+        # hacky way for to get known context -> InMemIOManager -> StepOrchestrationContext
         # for step handler testing
         return context.get_step_execution_context().get_known_state()
 
     dyn_producer().map(dyn_sink).collect()
+
+
+@job
+def input_metadata_simple_job():
+    @op
+    def simple_op_out_with_metadata() -> Output[int]:
+        return Output(
+            1,
+            metadata={
+                USER_DEFINED_K8S_CONFIG_KEY: {"container_config": MOCK_RUNTIME_RESOURCE_CONF}
+            },
+        )
+
+    @op(
+        ins={
+            "simple_op_out_with_metadata": In(
+                int, metadata={USER_DEFINED_INPUT_K8S_OP_MUTATION_KEY: True}
+            )
+        }
+    )
+    def simple_metadata_consumer(context: OpExecutionContext, simple_op_out_with_metadata: int):
+        context.log.info(f"received the following input: {simple_op_out_with_metadata}")
+
+    simple_metadata_consumer(simple_op_out_with_metadata())
+
+
+@job
+def multi_input_simple_job():
+    @op
+    def simple_out_one() -> Output[K8sOpMutatingWrapper]:
+        return Output(
+            K8sOpMutatingWrapper(1),
+            metadata={
+                USER_DEFINED_K8S_CONFIG_KEY: {
+                    "container_config": {
+                        "resources": {
+                            "requests": {"cpu": "1234m", "memory": "1Gi"},
+                            "limits": {"cpu": "1765m", "memory": "1Gi"},
+                        }
+                    }
+                }
+            },
+        )
+
+    @op
+    def simple_mem_override() -> Output[K8sOpMutatingWrapper]:
+        return Output(
+            K8sOpMutatingWrapper(1),
+            metadata={
+                USER_DEFINED_K8S_CONFIG_KEY: {
+                    "container_config": {
+                        "resources": {
+                            "requests": {"memory": "2Gi"},
+                            "limits": {"memory": "2Gi"},
+                        }
+                    }
+                }
+            },
+        )
+
+    @op
+    def dual_sink(
+        simple_out_one: K8sOpMutatingWrapper, simple_mem_override: K8sOpMutatingWrapper
+    ): ...
+
+    dual_sink(simple_out_one(), simple_mem_override())
+
+
+@dataclass
+class MockStepOrchestrationContext:
+    run_id: str
+    log: SqlEventLogStorage
 
 
 def _fetch_step_handler_context(
@@ -148,31 +236,9 @@ def _fetch_mutating_executor(instance, job_def, executor_config=None):
     )
 
 
-def _make_shared_mem_io_manager(inmem_io_manager: InMemoryIOManager) -> IOManagerDefinition:
-    @io_manager
-    def shared_mem_io_manager(_) -> InMemoryIOManager:
-        return inmem_io_manager
-
-    return shared_mem_io_manager
-
-
-def test_mutating_step_handler_runtime_override(
-    k8s_instance: DagsterInstance, kubeconfig_file: str
-):
-    """Using the `simple_producer_consumer` job, ensure that a simple output can be detected, eagerly loaded, and consumed as container context."""
+@pytest.fixture
+def mutating_step_handler(kubeconfig_file: str) -> K8sMutatingStepHandler:
     mock_k8s_client_batch_api = mock.MagicMock()
-    run_id = "de07af8f-d5f4-4a43-b545-132c3310999d"
-    shared_mem_io_manager = InMemoryIOManager()
-    io_manager_def = _make_shared_mem_io_manager(shared_mem_io_manager)
-    result = simple_producer_consumer.execute_in_process(
-        instance=k8s_instance, run_id=run_id, resources={"io_manager": io_manager_def}
-    )
-    assert result.success
-    recon_job = reconstructable(simple_producer_consumer)
-    executor = _fetch_mutating_executor(k8s_instance, recon_job)
-    step_handler_ctx = _fetch_step_handler_context(
-        recon_job, result.dagster_run, k8s_instance, executor, ["sink"]
-    )
     handler = K8sMutatingStepHandler(
         image="bizbuz",
         container_context=K8sContainerContext(
@@ -189,44 +255,178 @@ def test_mutating_step_handler_runtime_override(
     )
     # stub api client
     handler._api_client = mock.MagicMock()  # noqa: SLF001
-    with mock.patch.object(
-        StepExecutionContext, "get_io_manager", mock.MagicMock(return_value=shared_mem_io_manager)
-    ):
-        runtime_mutated_context = handler._get_container_context(step_handler_ctx)  # noqa: SLF001
+    return handler
+
+
+def test_get_step_output_records_simple(k8s_instance: DagsterInstance):
+    run_id = "de07af8f-d5f4-4a43-b545-132c3310999d"
+    result = simple_producer_consumer_job.execute_in_process(instance=k8s_instance, run_id=run_id)
+    assert result.success
+    event_conn = get_output_records_for_run_step(
+        cast(SqlEventLogStorage, k8s_instance.event_log_storage),
+        run_id,
+        "producer",
+    )
+    assert not event_conn.has_more
+    event_records = event_conn.records
+    assert len(event_records) == 1
+    event_entry = event_records[0].event_log_entry
+    output_data = event_entry.get_dagster_event().step_output_data
+    metadata = cast(JsonMetadataValue, output_data.metadata[USER_DEFINED_K8S_CONFIG_KEY])
+    UserDefinedDagsterK8sConfig.from_dict(metadata.data)
+
+
+def test_get_step_output_records_paginate(k8s_instance: DagsterInstance):
+    run_id = "de07af8f-d5f4-4a43-b545-132c3310999d"
+    result = dynamic_producer_consumer_job.execute_in_process(instance=k8s_instance, run_id=run_id)
+    assert result.success
+    upstream_step = "dyn_producer"
+    event_conn = get_output_records_for_run_step(
+        cast(SqlEventLogStorage, k8s_instance.event_log_storage),
+        run_id,
+        upstream_step,
+        limit=1,
+    )
+    assert event_conn.has_more
+    event_records = event_conn.records
+    assert len(event_records) == 1
+    event_entry = event_records[0].event_log_entry
+    output_data = event_entry.get_dagster_event().step_output_data
+    metadata = cast(JsonMetadataValue, output_data.metadata[USER_DEFINED_K8S_CONFIG_KEY])
+    UserDefinedDagsterK8sConfig.from_dict(metadata.data)
+    event_conn = get_output_records_for_run_step(
+        cast(SqlEventLogStorage, k8s_instance.event_log_storage),
+        run_id,
+        upstream_step,
+        cursor=event_conn.cursor,
+    )
+    assert not event_conn.has_more
+    event_records = event_conn.records
+    assert len(event_records) == 1
+    event_entry = event_records[0].event_log_entry
+    output_data = event_entry.get_dagster_event().step_output_data
+    metadata = cast(JsonMetadataValue, output_data.metadata[USER_DEFINED_K8S_CONFIG_KEY])
+    UserDefinedDagsterK8sConfig.from_dict(metadata.data)
+
+
+def test_mutating_step_handler_runtime_override(
+    k8s_instance: DagsterInstance, mutating_step_handler: K8sMutatingStepHandler
+):
+    """Using the `simple_producer_consumer` job, ensure that a simple output can be detected, eagerly loaded, and consumed as container context.
+
+    The detection of mutation is via the custom defined K8sOpMutatingWrapper type.
+    """
+    run_id = "de07af8f-d5f4-4a43-b545-132c3310999d"
+    result = simple_producer_consumer_job.execute_in_process(instance=k8s_instance, run_id=run_id)
+    assert result.success
+    recon_job = reconstructable(simple_producer_consumer_job)
+    executor = _fetch_mutating_executor(k8s_instance, recon_job)
+    step_handler_ctx = _fetch_step_handler_context(
+        recon_job, result.dagster_run, k8s_instance, executor, ["sink"]
+    )
+    runtime_mutated_context = mutating_step_handler._get_container_context(step_handler_ctx)  # noqa: SLF001
     assert (
         runtime_mutated_context.run_k8s_config.container_config.get("resources")
         == MOCK_RUNTIME_RESOURCE_CONF["resources"]
     )
     # check cache state
-    assert len(handler.container_ctx_cache) == 1
+    assert len(mutating_step_handler.container_ctx_cache) == 1
     # no need to stub execution context again as the step_input_cache should now hit. If not below will fail.
-    list(handler.terminate_step(step_handler_ctx))
+    list(mutating_step_handler.terminate_step(step_handler_ctx))
     # ensure clean events are handled
-    assert not handler.container_ctx_cache
+    assert not mutating_step_handler.container_ctx_cache
+
+
+def test_mutating_step_handler_cache_hit(
+    k8s_instance: DagsterInstance, mutating_step_handler: K8sMutatingStepHandler
+):
+    run_id = "de07af8f-d5f4-4a43-b545-132c3310999d"
+    result = simple_producer_consumer_job.execute_in_process(instance=k8s_instance, run_id=run_id)
+    assert result.success
+    recon_job = reconstructable(simple_producer_consumer_job)
+    executor = _fetch_mutating_executor(k8s_instance, recon_job)
+    step_handler_ctx = _fetch_step_handler_context(
+        recon_job, result.dagster_run, k8s_instance, executor, ["sink"]
+    )
+    runtime_mutated_context = mutating_step_handler._get_container_context(step_handler_ctx)  # noqa: SLF001
+    assert (
+        runtime_mutated_context.run_k8s_config.container_config.get("resources")
+        == MOCK_RUNTIME_RESOURCE_CONF["resources"]
+    )
+    mutating_step_handler._merge_input_configs = mock.MagicMock()  # noqa: SLF001
+    runtime_mutated_context = mutating_step_handler._get_container_context(step_handler_ctx)  # noqa: SLF001
+    mutating_step_handler._merge_input_configs.assert_not_called()  # noqa: SLF001
+
+
+def test_mutating_step_handler_dual_input(
+    k8s_instance: DagsterInstance, mutating_step_handler: K8sMutatingStepHandler
+):
+    run_id = "de07af8f-d5f4-4a43-b545-132c3310999d"
+    result = multi_input_simple_job.execute_in_process(instance=k8s_instance, run_id=run_id)
+    assert result.success
+    recon_job = reconstructable(multi_input_simple_job)
+    executor = _fetch_mutating_executor(k8s_instance, recon_job)
+    step_handler_ctx = _fetch_step_handler_context(
+        recon_job, result.dagster_run, k8s_instance, executor, ["dual_sink"]
+    )
+    runtime_mutated_context = mutating_step_handler._get_container_context(step_handler_ctx)  # noqa: SLF001
+    assert runtime_mutated_context.run_k8s_config.container_config.get("resources") == {
+        "requests": {"cpu": "1234m", "memory": "2Gi"},
+        "limits": {"cpu": "1765m", "memory": "2Gi"},
+    }
+    assert len(mutating_step_handler.container_ctx_cache) == 1
+    list(mutating_step_handler.terminate_step(step_handler_ctx))
+    assert not mutating_step_handler.container_ctx_cache
+
+
+def test_mutating_step_handler_input_metadata_trigger(
+    k8s_instance: DagsterInstance, mutating_step_handler: K8sMutatingStepHandler
+):
+    """Using the `input_metadata_simple_job` job, ensure that a simple output can be detected, eagerly loaded, and consumed as container context.
+
+    The detection of mutation is via input metadata key by USER_DEFINED_INPUT_K8S_OP_MUTATION_KEY.
+    """
+    run_id = "de07af8f-d5f4-4a43-b545-132c3310999d"
+    result = input_metadata_simple_job.execute_in_process(instance=k8s_instance, run_id=run_id)
+    assert result.success
+    recon_job = reconstructable(input_metadata_simple_job)
+    executor = _fetch_mutating_executor(k8s_instance, recon_job)
+    step_handler_ctx = _fetch_step_handler_context(
+        recon_job, result.dagster_run, k8s_instance, executor, ["simple_metadata_consumer"]
+    )
+    runtime_mutated_context = mutating_step_handler._get_container_context(step_handler_ctx)  # noqa: SLF001
+    assert (
+        runtime_mutated_context.run_k8s_config.container_config.get("resources")
+        == MOCK_RUNTIME_RESOURCE_CONF["resources"]
+    )
+    # check cache state
+    assert len(mutating_step_handler.container_ctx_cache) == 1
+    # no need to stub execution context again as the step_input_cache should now hit. If not below will fail.
+    list(mutating_step_handler.terminate_step(step_handler_ctx))
+    # ensure clean events are handled
+    assert not mutating_step_handler.container_ctx_cache
 
 
 def test_mutating_step_handler_dynamic_runtime_override(
-    k8s_instance: DagsterInstance, kubeconfig_file: str
+    k8s_instance: DagsterInstance, mutating_step_handler: K8sMutatingStepHandler
 ):
     """Using the `dynamic_producer_consumer` job, validate container context changes with respect to runtime dynamic outputs.
 
     We do this by executing the job in memory as normal, we then construct a StepOrchestration context by pulling
     various state from the in memory job execution and reconstructing the orchestration context by hand.
     The constructed orchestration context should be representative of what the step orchestration context and known state
-    would be when the actual job was ran.
+    would be when the actual job is ran.
     """
-    mock_k8s_client_batch_api = mock.MagicMock()
     run_id = "de07af8f-d5f4-4a43-b545-132c3310999d"
-    shared_mem_io_manager = InMemoryIOManager()
-    io_manager_def = _make_shared_mem_io_manager(shared_mem_io_manager)
-    result = dynamic_producer_consumer.execute_in_process(
-        instance=k8s_instance, run_id=run_id, resources={"io_manager": io_manager_def}
+    result = dynamic_producer_consumer_job.execute_in_process(
+        instance=k8s_instance,
+        run_id=run_id,
     )
     assert result.success
     # for each mapping output, check the container context is propagated properly
     for i in [3, 4]:
         dyn_known_state = result.output_for_node("dyn_sink")[str(i)]
-        recon_job = reconstructable(dynamic_producer_consumer)
+        recon_job = reconstructable(dynamic_producer_consumer_job)
         executor = _fetch_mutating_executor(k8s_instance, recon_job)
         step_handler_ctx = _fetch_step_handler_context(
             recon_job,
@@ -236,46 +436,27 @@ def test_mutating_step_handler_dynamic_runtime_override(
             [f"dyn_sink[{i}]"],
             dyn_known_state,
         )
-        handler = K8sMutatingStepHandler(
-            image="bizbuz",
-            container_context=K8sContainerContext(
-                namespace="foo",
-                resources={
-                    "requests": {"cpu": "128m", "memory": "64Mi"},
-                    "limits": {"cpu": "500m", "memory": "1000Mi"},
-                },
-            ),
-            load_incluster_config=False,
-            kubeconfig_file=kubeconfig_file,
-            k8s_client_batch_api=mock_k8s_client_batch_api,
-            op_mutation_enabled=True,
-        )
-        # stub api client
-        handler._api_client = mock.MagicMock()  # noqa: SLF001
-        with mock.patch.object(
-            StepExecutionContext,
-            "get_io_manager",
-            mock.MagicMock(return_value=shared_mem_io_manager),
-        ):
-            runtime_mutated_context = handler._get_container_context(step_handler_ctx)  # noqa: SLF001
+        runtime_mutated_context = mutating_step_handler._get_container_context(step_handler_ctx)  # noqa: SLF001
         assert runtime_mutated_context.run_k8s_config.container_config.get("resources") == {
             "requests": {"cpu": f"{i}234m", "memory": f"{i}Gi"},
             "limits": {"cpu": f"{i}765m", "memory": f"{i}Gi"},
         }
         # check cache state
-        assert len(handler.container_ctx_cache) == 1
+        assert len(mutating_step_handler.container_ctx_cache) == 1
         # no need to stub execution context again as the step_input_cache should now hit. If not below will fail.
-        list(handler.terminate_step(step_handler_ctx))
+        list(mutating_step_handler.terminate_step(step_handler_ctx))
         # ensure clean events are handled
-        assert not handler.container_ctx_cache
+        assert not mutating_step_handler.container_ctx_cache
 
 
-def test_mutating_step_handler_no_runtime_override(k8s_instance: DagsterInstance, kubeconfig_file):
-    """Ensure that when disabled, we fallback to the behavior of the  K8sStepHandler."""
-    mock_k8s_client_batch_api = mock.MagicMock()
-    result = simple_producer_consumer.execute_in_process(instance=k8s_instance)
+def test_mutating_step_handler_no_runtime_override(
+    k8s_instance: DagsterInstance, mutating_step_handler: K8sMutatingStepHandler
+):
+    """Ensure that when disabled, we fallback to the behavior of the K8sStepHandler."""
+    mutating_step_handler.op_mutation_enabled = False
+    result = simple_producer_consumer_job.execute_in_process(instance=k8s_instance)
     assert result.success
-    recon_job = reconstructable(simple_producer_consumer)
+    recon_job = reconstructable(simple_producer_consumer_job)
     executor = _fetch_mutating_executor(k8s_instance, recon_job)
     step_handler_ctx = _fetch_step_handler_context(
         recon_job, result.dagster_run, k8s_instance, executor, ["sink"]
@@ -284,23 +465,10 @@ def test_mutating_step_handler_no_runtime_override(k8s_instance: DagsterInstance
         "requests": {"cpu": "128m", "memory": "64Mi"},
         "limits": {"cpu": "500m", "memory": "1000Mi"},
     }
-    handler = K8sMutatingStepHandler(
-        image="bizbuz",
-        container_context=K8sContainerContext(
-            namespace="foo",
-            resources=initial_resources,
-        ),
-        load_incluster_config=False,
-        kubeconfig_file=kubeconfig_file,
-        k8s_client_batch_api=mock_k8s_client_batch_api,
-        op_mutation_enabled=False,
-    )
-    runtime_mutated_context = handler._get_container_context(step_handler_ctx)  # noqa: SLF001
+    runtime_mutated_context = mutating_step_handler._get_container_context(step_handler_ctx)  # noqa: SLF001
     assert (
         runtime_mutated_context.run_k8s_config.container_config.get("resources")
         == initial_resources
     )
-    handler._api_client = mock.Mock()  # noqa: SLF001
-    assert len(handler.container_ctx_cache) == 1
-    list(handler.terminate_step(step_handler_ctx))
-    assert not handler.container_ctx_cache
+    assert not mutating_step_handler.container_ctx_cache
+    list(mutating_step_handler.terminate_step(step_handler_ctx))

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_mutating_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_mutating_executor.py
@@ -1,14 +1,15 @@
-from typing import List
+from typing import List, Sequence, cast
 from unittest import mock
 
 from dagster import (
     DagsterInstance,
     DagsterRun,
+    DynamicOut,
+    DynamicOutput,
     Executor,
     InitExecutorContext,
     InMemoryIOManager,
     IOManagerDefinition,
-    JobDefinition,
     OpExecutionContext,
     StepExecutionContext,
     io_manager,
@@ -21,6 +22,8 @@ from dagster._core.definitions import ReconstructableJob
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.context.system import PlanData, PlanOrchestrationContext
 from dagster._core.execution.context_creation_job import create_context_free_log_manager
+from dagster._core.execution.plan.state import KnownExecutionState
+from dagster._core.execution.plan.step import ExecutionStep
 from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.step_delegating import StepHandlerContext
 from dagster._grpc.types import ExecuteStepArgs
@@ -52,10 +55,38 @@ def simple_producer_consumer():
         return MOCK_K8s_OUTPUT
 
     @op
-    def sink(context: OpExecutionContext, producer: K8sOpMutatingOutput):
-        context.log.info(f"received the following input: {producer}")
+    def sink(context: OpExecutionContext, producer: K8sOpMutatingOutput) -> KnownExecutionState:
+        _ = producer
+        return context.get_step_execution_context().get_known_state()
 
     sink(producer())
+
+
+@job
+def dynamic_producer_consumer():
+    @op(out=DynamicOut(K8sOpMutatingOutput))
+    def dyn_producer():
+        for i in [3, 4]:
+            k8s_out = K8sOpMutatingOutput(
+                {
+                    "container_config": {
+                        "resources": {
+                            "requests": {"cpu": f"{i}234m", "memory": f"{i}Gi"},
+                            "limits": {"cpu": f"{i}765m", "memory": f"{i}Gi"},
+                        }
+                    }
+                }
+            )
+            yield DynamicOutput(k8s_out, str(i))
+
+    @op
+    def dyn_sink(context: OpExecutionContext, producer: K8sOpMutatingOutput) -> KnownExecutionState:
+        context.log.info(f"received the following input: {producer}")
+        # hacky way for me to get known context -> InMemIOManager -> StepOrchestrationContext
+        # for step handler testing
+        return context.get_step_execution_context().get_known_state()
+
+    dyn_producer().map(dyn_sink).collect()
 
 
 def _fetch_step_handler_context(
@@ -64,8 +95,11 @@ def _fetch_step_handler_context(
     instance: DagsterInstance,
     executor: Executor,
     steps: List[str],
+    known_state=None,
 ):
-    execution_plan = create_execution_plan(job_def)
+    execution_plan = create_execution_plan(
+        job_def, known_state=known_state, instance_ref=instance.get_ref()
+    )
     log_manager = create_context_free_log_manager(instance, dagster_run)
 
     plan_context = PlanOrchestrationContext(
@@ -92,14 +126,12 @@ def _fetch_step_handler_context(
     return StepHandlerContext(
         instance=instance,
         plan_context=plan_context,
-        steps=execution_plan.steps,
+        steps=cast(Sequence[ExecutionStep], execution_plan.steps),
         execute_step_args=execute_step_args,
     )
 
 
-def _fetch_mutating_executor(
-    instance: DagsterInstance, job_def: JobDefinition, executor_config=None
-):
+def _fetch_mutating_executor(instance, job_def, executor_config=None):
     process_result = process_config(
         resolve_to_config_type(_K8S_OP_EXECUTOR_CONFIG_SCHEMA),
         executor_config or {},
@@ -166,11 +198,76 @@ def test_mutating_step_handler_runtime_override(
         == MOCK_RUNTIME_RESOURCE_CONF["resources"]
     )
     # check cache state
-    assert len(handler.step_input_cache) == 1
+    assert len(handler.container_ctx_cache) == 1
     # no need to stub execution context again as the step_input_cache should now hit. If not below will fail.
     list(handler.terminate_step(step_handler_ctx))
     # ensure clean events are handled
-    assert not handler.step_input_cache
+    assert not handler.container_ctx_cache
+
+
+def test_mutating_step_handler_dynamic_runtime_override(
+    k8s_instance: DagsterInstance, kubeconfig_file: str
+):
+    """Using the `dynamic_producer_consumer` job, validate container context changes with respect to runtime dynamic outputs.
+
+    We do this by executing the job in memory as normal, we then construct a StepOrchestration context by pulling
+    various state from the in memory job execution and reconstructing the orchestration context by hand.
+    The constructed orchestration context should be representative of what the step orchestration context and known state
+    would be when the actual job was ran.
+    """
+    mock_k8s_client_batch_api = mock.MagicMock()
+    run_id = "de07af8f-d5f4-4a43-b545-132c3310999d"
+    shared_mem_io_manager = InMemoryIOManager()
+    io_manager_def = _make_shared_mem_io_manager(shared_mem_io_manager)
+    result = dynamic_producer_consumer.execute_in_process(
+        instance=k8s_instance, run_id=run_id, resources={"io_manager": io_manager_def}
+    )
+    assert result.success
+    # for each mapping output, check the container context is propagated properly
+    for i in [3, 4]:
+        dyn_known_state = result.output_for_node("dyn_sink")[str(i)]
+        recon_job = reconstructable(dynamic_producer_consumer)
+        executor = _fetch_mutating_executor(k8s_instance, recon_job)
+        step_handler_ctx = _fetch_step_handler_context(
+            recon_job,
+            result.dagster_run,
+            k8s_instance,
+            executor,
+            [f"dyn_sink[{i}]"],
+            dyn_known_state,
+        )
+        handler = K8sMutatingStepHandler(
+            image="bizbuz",
+            container_context=K8sContainerContext(
+                namespace="foo",
+                resources={
+                    "requests": {"cpu": "128m", "memory": "64Mi"},
+                    "limits": {"cpu": "500m", "memory": "1000Mi"},
+                },
+            ),
+            load_incluster_config=False,
+            kubeconfig_file=kubeconfig_file,
+            k8s_client_batch_api=mock_k8s_client_batch_api,
+            op_mutation_enabled=True,
+        )
+        # stub api client
+        handler._api_client = mock.MagicMock()  # noqa: SLF001
+        with mock.patch.object(
+            StepExecutionContext,
+            "get_io_manager",
+            mock.MagicMock(return_value=shared_mem_io_manager),
+        ):
+            runtime_mutated_context = handler._get_container_context(step_handler_ctx)  # noqa: SLF001
+        assert runtime_mutated_context.run_k8s_config.container_config.get("resources") == {
+            "requests": {"cpu": f"{i}234m", "memory": f"{i}Gi"},
+            "limits": {"cpu": f"{i}765m", "memory": f"{i}Gi"},
+        }
+        # check cache state
+        assert len(handler.container_ctx_cache) == 1
+        # no need to stub execution context again as the step_input_cache should now hit. If not below will fail.
+        list(handler.terminate_step(step_handler_ctx))
+        # ensure clean events are handled
+        assert not handler.container_ctx_cache
 
 
 def test_mutating_step_handler_no_runtime_override(k8s_instance: DagsterInstance, kubeconfig_file):
@@ -203,4 +300,7 @@ def test_mutating_step_handler_no_runtime_override(k8s_instance: DagsterInstance
         runtime_mutated_context.run_k8s_config.container_config.get("resources")
         == initial_resources
     )
-    assert not handler.step_input_cache
+    handler._api_client = mock.Mock()  # noqa: SLF001
+    assert len(handler.container_ctx_cache) == 1
+    list(handler.terminate_step(step_handler_ctx))
+    assert not handler.container_ctx_cache


### PR DESCRIPTION
## Summary & Motivation

Currently you aren't allowed to dynamically orchestrate a new op in a job executor from a prior ops output. This is because Dagster has a pretty hard delineation between a `StepOrchestrationContext` and a `StepExecutionContext`. I initially, simply wanted to pass in a custom `StepLauncher` as a resource that'd handle this for me. That level of abstraction moving forward would probably be the most sane way to implement this feature. Unfortunately, that would require a much more intrusive rewrite of the current `K8sStepHandler` as opposed to the more simple inheritance I have here. I'm also unsure as to whether that's possible. To avoid multiple, potentially expensive io_manager calls, we cache step inputs. That way, while a step is running and polling `_get_container_context` we don't reinitialize on every call. We save memory here by dropping the entry once the step is terminated. I considered the following 3 approaches to this problem:

 ### 1. Downstream `K8sDownstreamOpSpecPipe` Resource

I created the `K8sDownstreamOpSpecPipe` which would have an upstream op name/identify it's downstream steps and use this resource to log the configs it wanted to pass on. Here is a simple example of how this worked:

```python
@job(executor_def=k8s_op_mutating_executor)
def simple_job():
    @op
    def mock_op(context: OpExecutionContext, pipe: K8sDownstreamOpSpecPipe) -> int:
       # add and commit config like git. Resource would ensure you don't commit twice
       # as well as perform data checks on to ensure each entry is a valid k8s config
        pipe.add_downstream_configs(
            context,
            {
                "downstream": {
                    "pod_template_spec_metadata": {
                        "labels": {"example_label_key": "example_label_value"}
                    }
                }
            },
        )
        pipe.commit_downstream_configs(context)
        return 1

    @op(tags={'dagster-k8s/config': {..., 'from_ops': ['mock_op']}})
    def downstream(context: OpExecutionContext, mock_op: int):
        context.log.info(f"recieved input {mock_op}")

    downstream(mock_op())
```

Under the hood, this would emmit an `DagsterEngineEvent` that stored the k8s configs as `EngineEventData`. It would store the log on the downstream step itself, so querying for the config
would be super fast for the step handler. I created some custom queries to efficiently query the event log for step configs. The way I arrived at this solution was that I initially was going
to create a custom schema for passing down op to my mutating executor. As I developed the schema, I noticed it looked a lot like the event schema which is pretty generalizable.


Problems:
  - For dynamic outputs, ahead of time step validation and placement was not possible. I rely heavily on dynamic outputs.
  - Multiple source resolution became unintuitive and would be a pain to test and reason about.
  - Flooded my logs with EngineEvents. 
  - The `DagsterEventType` is probably a postgres enum under the hood, so I couldn't extend it how I want to for efficient log queries.
  - Scales poorly with engine events. Some of my op graphs are very large and scanning engine engine events from multiple steps, I thought would scale poorly (debatable)
    - Ended up implementing pagination schemes and querying only current steps, so it performed reasonably well in my stress tests.

### 2. Output Metadata Consumption

This is very similar to the approach I went with. Essentially, use output metadata if present, to configure the downstream op.

```python
@job(executor_def=k8s_op_mutating_executor)
def simple_job():
    @op
    def mock_op(context: OpExecutionContext) -> int:
        return Output(1, metadata={
            'dagster-k8s/config': {}  # k8s run configs
        })

    @op(tags={'dagster-k8s/config': {..., 'mutating_op': True}})
    def downstream(context: OpExecutionContext, mock_op: int):
        context.log.info(f"recieved input {mock_op}")

    downstream(mock_op())
```

Because we wouldn't want to eagerly load resources we didn't need, I checked the op tags and only eagerly loaded parent steps.
The main problem here was that after a while of hacking with it, I couldn't cleanly get output metadata from an input context.
I had to do some hacky nonsense to get the metadata from the event log by way of output handles and log queries. 
As such, I marked this a failure and moved on. 

### 3. Custom Output Wrapper Type (Implemented)

I created a custom dagster type called `K8sOpMutatingOutput`. This is a wrapper that can accept a value and a k8s config.

```python
@job(executor_def=k8s_op_mutating_executor)
def simple_prod_sink():
    @op
    def producer() -> K8sOpMutatingOutput:
        return K8sOpMutatingOutput(
            value=1,
            k8s_config={
                "container_config": {
                    "resources": {
                        "requests": {"cpu": "275m", "memory": "32Mi"},
                    }
                }
            },
        )

    @op
    def sink(context: OpExecutionContext, config: SleepConfig, producer: K8sOpMutatingOutput):
        context.log.info(f"sleeping {config.sleep_sec} seconds...")
        sleep(config.sleep_sec)

    sink(producer())
```

The advantage with this method is that I don't need any extra configs in my op tag. As soon as an op consumes
this type of input, I can recognize it, and naturally resolve runtime configs in a way that's immediately apparent
on job definition (by observing an ops inputs). 

Problems:
  * We __fake__ a step execution context, which means required resources for the op are loaded.
if these resources have destructive side effects, then this could lead to unintended consequences
or miscounting/labeling. The step handler now instantiates an execution context with the run launcher pod
not the op run pod. And the resources get instatiated twice.
  
    * as an enhancement, I plan to only instantiate the **required** io manager to load the particular input.
With this enancement, I'd consider it fair, although technically, the same problem for custom io managers exists.
  * During my stress tests, I didn't notice a particularly bad hit to step handler performance, but concievably, 
  this could get bad. Especially, with the implementation as it stands today, where a steps __entire__ execution
  context is built for eager loading.
  * If the value you are wrapping is particularly large, this will impact step handler performance

The reason we can use this is because for the steps we employ this on, our resources don't have destructive
or slow side affects and minimal input payloads.

### Other features

We cache K8sContainerContexts. This contributes slightly the the StepHandlers memory overhead, but is well worth
not resolving the same inputs multiple times. A potential enhancement here for outputs that are repeatedly used
is to implement an lru cache for rendering particular op output configs as well.

We get neat logging as well, for confirmation that inputs got picked up. On the op being configured, we get the following log.

<img width="1059" alt="image" src="https://github.com/user-attachments/assets/1c4f48d5-4643-46ad-9557-c841c6fc707d">



## How I Tested These Changes

  * unit tests:
    * Created a shared IOManager and run example in memory jobs. Recreate orchestration contexts for particular steps and use said io managers to mimic execution at a given point in time. Pull InMemIOManger & KnownState from executed jobs
    to recreate an accurate step handler context.
  * staging and production:
    * Our setup is the standard helm based, eks, setup, and our code locations have been able to run this executor reliably.
    * Had stress tests, where I launched multiple jobs with 100+ dynamic ops and observed sane perf
    * Had pods sleep so I can `kubectl get pod <op run pod> -oyaml` and observe proper propagation of k8s configs.


## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_

My goal here is to at least gather feedback from the team on this code and it's potential to be upstreamed.
I'd love to have this live in the dagster repo, but because of it's limitations, understand if it crosses
one too many boundaries. My rationale for why I think this not a violation of responsibility is because of the
precedent dynamic outputs set. If we are ok with a varying amount of ops in our graph, I think we can be ok 
if they manipulate the state of said ops. I can see why, after completing this exercise, these might be 2 separate concerns 
though. Would love to hear any and all feedback.